### PR TITLE
chore: Importing single mathlib modules instead of full library

### DIFF
--- a/ProvenZk.lean
+++ b/ProvenZk.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 import ProvenZk.Binary
 import ProvenZk.Gates
 import ProvenZk.Hash

--- a/ProvenZk/Ext/List.lean
+++ b/ProvenZk/Ext/List.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.Indexes
 
 namespace List
 

--- a/ProvenZk/Ext/Matrix.lean
+++ b/ProvenZk/Ext/Matrix.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Data.Matrix.Basic
 
 namespace Matrix
   def to_vector {t α} (m : Matrix (Fin t) Unit α ) : Vector α t := Vector.ofFn (fun i => m i 0)

--- a/ProvenZk/Ext/Range.lean
+++ b/ProvenZk/Ext/Range.lean
@@ -1,5 +1,5 @@
 import Init.Data.Range
-import Mathlib
+import Mathlib.Tactic.Linarith.Frontend
 
 namespace Std
 namespace Range

--- a/ProvenZk/Ext/Vector/Basic.lean
+++ b/ProvenZk/Ext/Vector/Basic.lean
@@ -1,4 +1,6 @@
-import Mathlib
+import Mathlib.Data.Vector.Snoc
+import Mathlib.Data.Matrix.Basic
+
 import ProvenZk.Binary
 import ProvenZk.Ext.Range
 import ProvenZk.Ext.List

--- a/ProvenZk/Gates.lean
+++ b/ProvenZk/Gates.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import Mathlib.Data.ZMod.Basic
 
 import ProvenZk.Binary


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
Replaced `import Mathlib` with importing individual Mathlib components to reduce compile time.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [x] Code is formatted akin to the other code in the repo.
- [x] Documentation has been updated if necessary.
