### PR TITLE
ci: bump actions/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y -v --default-toolchain leanprover/lean4:nightly
           echo "LAKE_VERSION=$(~/.elan/bin/lake --version)" >> $GITHUB_ENV
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: lake-packages
           key: "${{ env.LAKE_VERSION }}"


### PR DESCRIPTION
Updates cache action to v4 for future-proofing. Workflows behave the same.