### PR TITLE
chore: drop full Mathlib import from Ext/GetElem.lean (follow-up to PR #17)

### DIFF
--- a/ProvenZk/Ext/GetElem.lean
+++ b/ProvenZk/Ext/GetElem.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 theorem getElem?_eq_some_getElem_of_valid_index [GetElem cont idx elem domain] [(container: cont) → (index: idx) → Decidable (domain container index)] (h : domain container index):
   container[index]? = some container[index] := by
   simp [getElem?, *]


### PR DESCRIPTION
# Summary

Drop `import Mathlib` in `Ext/GetElem.lean`, because it's not used, and  
the module compiles faster on its own and in the build without it.

# Details

Found and verified this with Aristotle AI (Harmonic)

# Checklist

- [ x] Code is formatted akin to the other code in the repo.
- [ x] Documentation has been updated if necessary.
