### PR TITLE
chore: drop full Mathlib import from Lemmas.lean (follow-up to PR #17)

### DIFF
--- a/ProvenZk/Ext/GetElem.lean
+++ b/ProvenZk/Ext/GetElem.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 theorem getElem?_eq_some_getElem_of_valid_index [GetElem cont idx elem domain] [(container: cont) → (index: idx) → Decidable (domain container index)] (h : domain container index):
   container[index]? = some container[index] := by
   simp [getElem?, *]

--- a/ProvenZk/Lemmas.lean
+++ b/ProvenZk/Lemmas.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Algebra.Field.ZMod
 
 import ProvenZk.Gates
 import ProvenZk.Binary


### PR DESCRIPTION
# Summary

Drop `import Mathlib` in `Lemmas.lean`, and add `import Mathlib.Algebra.Field.ZMod` to improve compile times. 

# Details

Used Aristotle AI (Harmonic) to find and verify this.

# Checklist

- [ x] Code is formatted akin to the other code in the repo.
- [x ] Documentation has been updated if necessary.


